### PR TITLE
[PR] Change to support sequelize@6.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,8 @@ module.exports = function CommentPlugin( sequelizeDialect, settings ) {
 		}
 	];
 
-	var queryGenerator = sequelizeDialect.getQueryInterface().QueryGenerator;
+	const queryInterface = sequelizeDialect.getQueryInterface();
+	const queryGenerator = queryInterface.QueryGenerator || queryInterface.queryGenerator;
 
 	// Proxy each query generator method. The proxy will invoke the underlying / original
 	// method and then prefix the comment (if the option exists) before passing on the 


### PR DESCRIPTION
ref https://sequelize.org/master/manual/upgrade-to-v6.html

> All instances of QueryInterface and QueryGenerator have been renamed to their lowerCamelCase variants eg. queryInterface and queryGenerator when used as property names on Model and Dialect, the class names remain the same.